### PR TITLE
Support UTF-8 signature

### DIFF
--- a/lib/grooveshark/client.js
+++ b/lib/grooveshark/client.js
@@ -61,7 +61,7 @@
 
     Client.prototype.urlWithSig = function(body) {
       var sig;
-      sig = crypto.createHmac('md5', this.secret).update(JSON.stringify(body)).digest('hex');
+      sig = crypto.createHmac('md5', this.secret).update(JSON.stringify(body), 'utf-8').digest('hex');
       return "" + BASE_URL + "?sig=" + sig;
     };
 

--- a/src/grooveshark/client.coffee
+++ b/src/grooveshark/client.coffee
@@ -42,7 +42,7 @@ class Client
       })
 
   urlWithSig: (body) ->
-    sig = crypto.createHmac('md5', @secret).update(JSON.stringify(body)).digest('hex')
+    sig = crypto.createHmac('md5', @secret).update(JSON.stringify(body), 'utf-8').digest('hex')
     "#{BASE_URL}?sig=#{sig}"
 
   request: (method, parameters = {}, cb) ->


### PR DESCRIPTION
I had error message like 'incorrect method signature' when query with utf-8 string. Finally, I found encoding option when hash content is updated. (http://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding)
